### PR TITLE
Use unicrypto logger instead of root logger

### DIFF
--- a/unicrypto/__init__.py
+++ b/unicrypto/__init__.py
@@ -47,7 +47,7 @@ for prefname in pref_to_module:
 
 
 def get_cipher_by_name(ciphername, cryptolibname):
-	logging.debug('symmetric using "%s" for "%s"' % (cryptolibname, ciphername))
+	logger.debug('symmetric using "%s" for "%s"' % (cryptolibname, ciphername))
 	moduleName = 'unicrypto.backends.%s.%s' % (cryptolibname.lower(), ciphername)
 	return import_from(moduleName , ciphername)
 


### PR DESCRIPTION
Following up on #10 in commit https://github.com/skelsec/unicrypto/commit/8b05303696c55020e8c36e3710b37e3cb47abf25 one logging statement was missed, which still uses the root logger. This is changed now, so everything uses the created `unicrypto` logger.